### PR TITLE
fix breadcrumbs.go

### DIFF
--- a/core/util/breadcrumbs.go
+++ b/core/util/breadcrumbs.go
@@ -5,21 +5,26 @@ import (
 	"strings"
 )
 
-func GenerateBreadcrumbs(path string) map[string]interface{} {
-	breadcrumbs := make(map[string]interface{})
-	parts := strings.Split(path, "/")
+type Breadcrumb struct {
+	Name string
+	Path string
+}
+
+func GenerateBreadcrumbs(path string) []Breadcrumb {
+	var breadcrumbs []Breadcrumb
+	splitted := strings.Split(path, "/")
 	fullPath := "/s3"
-	for i, part := range parts {
-		if part == "" {
+	for i, s := range splitted {
+		if s == "" {
 			continue
 		}
-		fullPath += "/" + part
+		fullPath += "/" + s
 
 		r, _ := regexp.Compile(`.*\..*`)
-		if i == len(parts)-1 && r.Match([]byte(part)) {
-			breadcrumbs[part] = fullPath + "?action=dl"
+		if i == len(splitted)-1 && r.Match([]byte(s)) {
+			breadcrumbs = append(breadcrumbs, Breadcrumb{Name: s, Path: fullPath + "?action=dl"})
 		} else {
-			breadcrumbs[part] = fullPath
+			breadcrumbs = append(breadcrumbs, Breadcrumb{Name: s, Path: fullPath})
 		}
 	}
 	return breadcrumbs

--- a/core/util/breadcrumbs_test.go
+++ b/core/util/breadcrumbs_test.go
@@ -8,29 +8,40 @@ import (
 func TestGenerateBreadcrumbs(t *testing.T) {
 	tests := []struct {
 		input    string
-		expected map[string]interface{}
+		expected []Breadcrumb
 	}{
 		{
 			input: "/fuga/fugafuga/aaa.txt",
-			expected: map[string]interface{}{
-				"fuga":     "/s3/fuga",
-				"fugafuga": "/s3/fuga/fugafuga",
-				"aaa.txt":  "/s3/fuga/fugafuga/aaa.txt?action=dl",
+			expected: []Breadcrumb{
+				{Name: "fuga", Path: "/s3/fuga"},
+				{Name: "fugafuga", Path: "/s3/fuga/fugafuga"},
+				{Name: "aaa.txt", Path: "/s3/fuga/fugafuga/aaa.txt?action=dl"},
 			},
 		},
 		{
 			input: "/hoge/fuga/piyo",
-			expected: map[string]interface{}{
-				"hoge": "/s3/hoge",
-				"fuga": "/s3/hoge/fuga",
-				"piyo": "/s3/hoge/fuga/piyo",
+			expected: []Breadcrumb{
+				{Name: "hoge", Path: "/s3/hoge"},
+				{Name: "fuga", Path: "/s3/hoge/fuga"},
+				{Name: "piyo", Path: "/s3/hoge/fuga/piyo"},
 			},
 		},
 		{
 			input: "/s3/hoge",
-			expected: map[string]interface{}{
-				"s3":   "/s3/s3",
-				"hoge": "/s3/s3/hoge",
+			expected: []Breadcrumb{
+				{Name: "s3", Path: "/s3/s3"},
+				{Name: "hoge", Path: "/s3/s3/hoge"},
+			},
+		},
+		{
+			input: "/files/2024/0706/1845/txt/1234.txt",
+			expected: []Breadcrumb{
+				{Name: "files", Path: "/s3/files"},
+				{Name: "2024", Path: "/s3/files/2024"},
+				{Name: "0706", Path: "/s3/files/2024/0706"},
+				{Name: "1845", Path: "/s3/files/2024/0706/1845"},
+				{Name: "txt", Path: "/s3/files/2024/0706/1845/txt"},
+				{Name: "1234.txt", Path: "/s3/files/2024/0706/1845/txt/1234.txt?action=dl"},
 			},
 		},
 	}

--- a/static/index.html
+++ b/static/index.html
@@ -15,9 +15,9 @@
             <div class="flex justify-between">
                 <div class="text-lg">
                     <a href="/s3" class="text-cyan-400 underline-offset-2 hover:opacity-60">s3:</a>
-                    {{range $key, $value := .Breadcrumbs}}
-                    <span> / <a href="{{$value}}"
-                            class="text-cyan-400 underline-offset-2 hover:opacity-60">{{$key}}</a></span>
+                    {{range .Breadcrumbs}}
+                    <span> / <a href="{{.Path}}"
+                            class="text-cyan-400 underline-offset-2 hover:opacity-60">{{.Name}}</a></span>
                     {{end}}
                 </div>
                 <div>


### PR DESCRIPTION
Closes #6 

パンくずリストをmapで管理せず、sliceで管理するよう修正。
※mapは順番を保証しない