### PR TITLE
Fix listobjects_v2.go logic of extracting key

### DIFF
--- a/core/amazon/awssdk/listobjects_v2.go
+++ b/core/amazon/awssdk/listobjects_v2.go
@@ -68,7 +68,7 @@ func ListObjects(rootDir string, uploadDirName string) ([]Item, error) {
 		}
 		if !info.IsDir() {
 			items = append(items, Item{
-				Key:  filepath.ToSlash(path[len(uploadDirName+"/"):]),
+				Key:  ExtractKey(path),
 				Size: info.Size(),
 			})
 		}
@@ -84,4 +84,14 @@ func IsTruncated(items []Item) (bool, []Item) {
 	} else {
 		return false, items
 	}
+}
+
+func ExtractKey(path string) string {
+	splitted := strings.Split(path, "/")
+	if len(splitted) < 3 {
+		slog.Warn("Failed to extract key. Unexpected number of slash in path.", "path", path)
+		return ""
+	}
+
+	return strings.Join(splitted[2:], "/")
 }

--- a/core/amazon/awssdk/listobjects_v2_test.go
+++ b/core/amazon/awssdk/listobjects_v2_test.go
@@ -17,17 +17,17 @@ func TestListObjects(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	err = os.MkdirAll(filepath.Join(tempDir, "dir1"), os.ModePerm)
+	err = os.MkdirAll(filepath.Join(tempDir, "test-bucket", "dir1"), os.ModePerm)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = os.WriteFile(filepath.Join(tempDir, "file1.txt"), []byte("file1 content"), os.ModePerm)
+	err = os.WriteFile(filepath.Join(tempDir, "test-bucket", "file1.txt"), []byte("file1 content"), os.ModePerm)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = os.WriteFile(filepath.Join(tempDir, "dir1", "file2.txt"), []byte("file2 content"), os.ModePerm)
+	err = os.WriteFile(filepath.Join(tempDir, "test-bucket", "dir1", "file2.txt"), []byte("file2 content"), os.ModePerm)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,4 +79,13 @@ func TestIsTruncated(t *testing.T) {
 	assert.Equal(t, isTruncated1200, true)
 	assert.Equal(t, actualItems1200, items1200[:1000])
 
+}
+
+func TestExtractKey(t *testing.T) {
+	assert.Equal(t, ExtractKey("upload/test-bucket/aaa.txt"), "aaa.txt")
+	assert.Equal(t, ExtractKey("upload/test-bucket/dir1/aaa.txt"), "dir1/aaa.txt")
+	assert.Equal(t, ExtractKey("upload/test-bucket/dir1/dir2/dir3/dir4/aaa.txt"), "dir1/dir2/dir3/dir4/aaa.txt")
+	assert.Equal(t, ExtractKey("upload/aaa.txt"), "")
+	assert.Equal(t, ExtractKey("aaa.txt"), "")
+	assert.Equal(t, ExtractKey(""), "")
 }


### PR DESCRIPTION
I fixed an issue where the key values in the response from the AWS SDK's ListObjectV2 request included the bucket name. Now, the bucket name is removed from the key.

BEFORE: "upload/files/dir1/aaa.txt" -> "test-bucket/dir1/aaa.txt"
AFTER: "upload/files/dir1/aaa.txt" -> "dir1/aaa.txt"